### PR TITLE
chore: add nix flake support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1753121425,
+        "narHash": "sha256-TVcTNvOeWWk1DXljFxVRp+E0tzG1LhrVjOGGoMHuXio=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "644e0fc48951a860279da645ba77fe4a6e814c5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753694789,
+        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,8 +27,8 @@
           src = self;
           dependencies = with pkgs.vimPlugins; [
             nui-nvim
-            nvim-dap
             nvim-nio
+            nvim-dap
             nvim-dap-virtual-text
             noice-nvim
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "A Neovim plugin that provides AL (Application Language) support for Microsoft Dynamics 365 Business Central development. ";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+  };
+
+  outputs = inputs @ {
+    self,
+    flake-parts,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" "x86_64-windows" "aarch64-windows"];
+
+      perSystem = {
+        pkgs,
+        system,
+        ...
+      }: {
+        packages.default = pkgs.vimUtils.buildVimPlugin {
+          pname = "al-nvim";
+          version = "unstable";
+          src = self;
+          dependencies = with pkgs.vimPlugins; [
+            nui-nvim
+            nvim-dap
+            nvim-nio
+            nvim-dap-virtual-text
+            noice-nvim
+          ];
+          nvimSkipModule = [
+            "al.luasnippets.al.trigger"
+            "al.luasnippets.al.procedure"
+            "al.luasnippets.al.report-column"
+            "al.luasnippets.al.report"
+            "al.luasnippets.al.report-dataitem"
+            "al.luasnippets.al.report-layout"
+            "al.debugger"
+          ];
+        };
+      };
+    };
+}


### PR DESCRIPTION
This PR introduces Nix flake support for the Neovim plugin, enabling reproducible builds and easier development workflows across multiple platforms.