### PR TITLE
refactor: improve LSP path resolution and remove debug statement

### DIFF
--- a/lua/al/integrations/luasnip.lua
+++ b/lua/al/integrations/luasnip.lua
@@ -7,7 +7,6 @@ M.setup = function()
     end
 
     local snippet_path = debug.getinfo(1).source:sub(2):gsub("integrations/luasnip.lua", "luasnippets")
-    print(snippet_path)
     require("luasnip.loaders.from_lua").lazy_load({ paths = snippet_path })
 end
 


### PR DESCRIPTION
- Removed an unnecessary debug `print` statement in `lua/al/integrations/luasnip.lua`.

- Refactored the `find_lsp_path` function in `lua/al/lsp.lua` to enhance:

 - Directory scanning using `vim.loop.fs_scandir` for better performance.

 - Error handling when scanning directories.

 - Simplified path construction for different operating systems.