### PR TITLE
Remove forced DapBreakpoint icon to respect user configuration

### DIFF
--- a/lua/al/debugger.lua
+++ b/lua/al/debugger.lua
@@ -17,8 +17,6 @@ function M.setup()
 
     dapui.setup()
 
-    vim.fn.sign_define("DapBreakpoint", { text = "🐞" })
-
     dap.listeners.after.initialize.al = function()
         dapui.open()
     end


### PR DESCRIPTION
The plugin currently defines a default icon for `DapBreakpoint`, which overrides any user configuration and prevents users from customizing their debugger signs.

This change removes the default icon assignment, allowing users to define their preferred `DapBreakpoint` symbol in their own Neovim configuration.

No other functionality is affected.