### PR TITLE
use client:request colon-call to silence Nvim 0.12 deprecation

### DIFF
--- a/lua/al/buf.lua
+++ b/lua/al/buf.lua
@@ -60,7 +60,7 @@ M.set_active_file = function(client, buf)
         },
         sequence = M.sequence,
     }
-    client.request("al/didChangeActiveDocument", params, function() end)
+    client:request("al/didChangeActiveDocument", params, function() end)
     M.sequence = M.sequence + 1
 end
 

--- a/lua/al/debugger.lua
+++ b/lua/al/debugger.lua
@@ -130,7 +130,7 @@ end
 -- Get the path to the appropriate proxy binary for the current platform
 function M.get_proxy_path()
     local plugin_path = debug.getinfo(1, "S").source:sub(2):match("(.*[/\\])") .. "../.."
-    local os_name = vim.loop.os_uname().sysname:lower()
+    local os_name = vim.uv.os_uname().sysname:lower()
 
     if os_name:match("windows") then
         -- Check if .exe exists, otherwise use .bat (temporary fallback)
@@ -143,7 +143,7 @@ function M.get_proxy_path()
         end
     elseif os_name:match("darwin") then
         -- Check if we're on Apple Silicon
-        local arch = vim.loop.os_uname().machine:lower()
+        local arch = vim.uv.os_uname().machine:lower()
         if arch:match("arm64") then
             return plugin_path .. "/bin/al-debug-proxy-darwin-arm64"
         else

--- a/lua/al/editor_commands/publish.lua
+++ b/lua/al/editor_commands/publish.lua
@@ -33,15 +33,19 @@ end
 
 --- Install a temporary window/logMessage handler that watches for publish
 --- completion or failure messages from the AL server.
+--- Scoped to the specific client via client.handlers to avoid mutating the
+--- global vim.lsp.handlers table.
 ---@param client vim.lsp.Client
 ---@return fun() cleanup function to remove the handler
 local function watch_log_messages(client)
-    local prev_handler = vim.lsp.handlers["window/logMessage"]
+    local prev_handler = client.handlers["window/logMessage"]
 
-    vim.lsp.handlers["window/logMessage"] = function(err, result, ctx, cfg)
-        -- Chain to previous handler
+    client.handlers["window/logMessage"] = function(err, result, ctx, cfg)
+        -- Chain to previous per-client handler (or fall back to global)
         if prev_handler then
             prev_handler(err, result, ctx, cfg)
+        elseif vim.lsp.handlers["window/logMessage"] then
+            vim.lsp.handlers["window/logMessage"](err, result, ctx, cfg)
         end
 
         if not result or not result.message then
@@ -59,16 +63,16 @@ local function watch_log_messages(client)
             emit_progress(client.id, "end", "Published successfully")
             Util.info("Package published successfully")
             -- Restore original handler
-            vim.lsp.handlers["window/logMessage"] = prev_handler
+            client.handlers["window/logMessage"] = prev_handler
         elseif msg:match("Failed to publish") or msg:match("PublishingFailed") then
             emit_progress(client.id, "end", "Publish failed")
             Util.error("Publish failed: " .. msg)
-            vim.lsp.handlers["window/logMessage"] = prev_handler
+            client.handlers["window/logMessage"] = prev_handler
         end
     end
 
     return function()
-        vim.lsp.handlers["window/logMessage"] = prev_handler
+        client.handlers["window/logMessage"] = prev_handler
     end
 end
 

--- a/lua/al/editor_commands/restart_lsp.lua
+++ b/lua/al/editor_commands/restart_lsp.lua
@@ -10,7 +10,7 @@ local restart_lsp = function()
     Util.info("Restarting AL language server...")
 
     for _, client in ipairs(clients) do
-        vim.lsp.stop_client(client.id)
+        client:stop()
     end
 
     -- Defer to let clients detach, then re-trigger FileType on all AL buffers.

--- a/lua/al/integrations/dap.lua
+++ b/lua/al/integrations/dap.lua
@@ -99,7 +99,7 @@ end
 -- Get the path to the appropriate proxy binary for the current platform
 function M.get_proxy_path()
     local plugin_path = debug.getinfo(1, "S").source:sub(2):match("(.*[/\\])") .. "../../.."
-    local os_name = vim.loop.os_uname().sysname:lower()
+    local os_name = vim.uv.os_uname().sysname:lower()
 
     if os_name:match("windows") then
         -- Check if .exe exists, otherwise use .bat (temporary fallback)
@@ -112,7 +112,7 @@ function M.get_proxy_path()
         end
     elseif os_name:match("darwin") then
         -- Check if we're on Apple Silicon
-        local arch = vim.loop.os_uname().machine:lower()
+        local arch = vim.uv.os_uname().machine:lower()
         if arch:match("arm64") then
             return plugin_path .. "/bin/al-debug-proxy-darwin-arm64"
         else

--- a/lua/al/lsp.lua
+++ b/lua/al/lsp.lua
@@ -173,20 +173,20 @@ end
 
 function M.find_lsp_path(basePath, is_dll)
     local path = ""
-    local os_name = vim.loop.os_uname().sysname:lower()
+    local os_name = vim.uv.os_uname().sysname:lower()
     local sep = os_name:match("windows") and "\\" or "/"
     local binary_folder = sep .. "bin" .. sep .. (os_name:match("windows") and "win32" or "linux") .. sep
 
     -- Expand ~ to full path
     local expanded_base = vim.fn.expand(basePath)
 
-    local handle = vim.loop.fs_scandir(expanded_base)
+    local handle = vim.uv.fs_scandir(expanded_base)
     if not handle then
         return nil
     end
 
     while true do
-        local filename, t = vim.loop.fs_scandir_next(handle)
+        local filename, t = vim.uv.fs_scandir_next(handle)
         if not filename then
             break
         end

--- a/lua/al/multiproject.lua
+++ b/lua/al/multiproject.lua
@@ -601,7 +601,7 @@ function M.on_workspace_loaded(ws)
     -- AL buffers so they start a new client with the correct workspace root_dir.
     local had_clients = #vim.lsp.get_clients({ name = "al_ls" }) > 0
     for _, client in ipairs(vim.lsp.get_clients({ name = "al_ls" })) do
-        vim.lsp.stop_client(client.id)
+        client:stop()
     end
     if had_clients then
         -- Defer until the stopped clients have detached from their buffers,
@@ -639,7 +639,7 @@ function M.on_workspace_closed()
 
     -- Stop al_ls clients; they will restart with per-project root_dir on next BufEnter
     for _, client in ipairs(vim.lsp.get_clients({ name = "al_ls" })) do
-        vim.lsp.stop_client(client.id)
+        client:stop()
     end
 end
 

--- a/lua/al/multiproject.lua
+++ b/lua/al/multiproject.lua
@@ -524,22 +524,29 @@ local function _on_lsp_attach(client)
     end)
 end
 
---- Register global LSP notification handlers for multi-project mode.
---- Safe to call multiple times — chains to any existing handler.
+--- Register LSP notification handlers for multi-project mode.
+--- Uses LspAttach to scope handlers to al_ls clients via client.handlers,
+--- avoiding global vim.lsp.handlers mutation (preferred in nvim 0.10+).
+--- Safe to call multiple times — the augroup is cleared on each call.
 local function _register_notification_handlers()
-    local prev = vim.lsp.handlers["al/projectsLoadedNotification"]
-    vim.lsp.handlers["al/projectsLoadedNotification"] = function(err, result, ctx, config)
-        if result and type(result.projects) == "table" then
-            local Workspace = require("al.workspace")
-            for _, project_path in ipairs(result.projects) do
-                local pnorm = norm(project_path)
-                Workspace.hasProjectClosureLoaded[pnorm] = true
+    vim.api.nvim_create_autocmd("LspAttach", {
+        group = vim.api.nvim_create_augroup("al_multiproject_handlers", { clear = true }),
+        callback = function(ev)
+            local client = vim.lsp.get_client_by_id(ev.data.client_id)
+            if not client or client.name ~= "al_ls" then
+                return
             end
-        end
-        if prev then
-            prev(err, result, ctx, config)
-        end
-    end
+            client.handlers["al/projectsLoadedNotification"] = function(_, result, _, _)
+                if result and type(result.projects) == "table" then
+                    local Workspace = require("al.workspace")
+                    for _, project_path in ipairs(result.projects) do
+                        local pnorm = norm(project_path)
+                        Workspace.hasProjectClosureLoaded[pnorm] = true
+                    end
+                end
+            end
+        end,
+    })
 end
 
 --- The currently active project folder (exposed for testing).

--- a/lua/al/workspace.lua
+++ b/lua/al/workspace.lua
@@ -114,7 +114,7 @@ M.set_active = function(client, buf)
         settings = settings,
     }
 
-    client.request(client, "al/setActiveWorkspace", request, M.on_set_active_response)
+    client:request("al/setActiveWorkspace", request, M.on_set_active_response)
 end
 
 ---@param err? lsp.ResponseError
@@ -142,8 +142,7 @@ function M.on_set_active_response(err, result, ctx, config)
     end
 
     if not M.hasProjectClosureLoaded[ws.root] then
-        client.request(
-            client,
+        client:request(
             "al/hasProjectClosureLoadedRequest",
             { workspacePath = ws.root },
             function(closure_err, closure_result)

--- a/tests/al/editor_commands/restart_lsp_spec.lua
+++ b/tests/al/editor_commands/restart_lsp_spec.lua
@@ -23,16 +23,20 @@ describe("al.editor_commands.restart_lsp", function()
 
     it("stops all al_ls clients", function()
         local stopped = {}
-        local orig_stop = vim.lsp.stop_client
-        vim.lsp.stop_client = function(id) table.insert(stopped, id) end
+        local make_client = function(id)
+            return {
+                id = id,
+                name = "al_ls",
+                stop = function(self) table.insert(stopped, self.id) end,
+            }
+        end
         local restore = helpers.stub_get_clients({
-            { id = 1, name = "al_ls" },
-            { id = 2, name = "al_ls" },
+            make_client(1),
+            make_client(2),
         })
         local notify = helpers.capture_notify()
         restart_lsp()
         assert.are.same({ 1, 2 }, stopped)
-        vim.lsp.stop_client = orig_stop
         restore()
         notify.restore()
     end)

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -9,6 +9,7 @@ function M.make_mock_client(opts)
         id = opts.id or 1,
         name = "al_ls",
         offset_encoding = "utf-16",
+        handlers = {},
         requests = {},
         request = function(self, method, params, cb)
             table.insert(self.requests, { method = method, params = params })


### PR DESCRIPTION
client.request(...) was deprecated in Neovim 0.12 and will be removed in 0.13. Switched the three remaining call sites to the colon-call form
