### PR TITLE
feat(lsp): macOS / Darwin support

### DIFF
--- a/lua/al/config.lua
+++ b/lua/al/config.lua
@@ -24,7 +24,8 @@ local M = {}
 ---@field lsp al.Config.LSP
 ---@field multiproject al.Config.Multiproject
 local defaults = {
-    vscodeExtensionsPath = "~\\.vscode\\extensions\\",
+    vscodeExtensionsPath = vim.uv.os_uname().sysname:lower():match("windows") and "~\\.vscode\\extensions\\"
+        or "~/.vscode/extensions/",
     integrations = {
         luasnip = true,
         treesitter = true,

--- a/lua/al/lsp.lua
+++ b/lua/al/lsp.lua
@@ -175,7 +175,8 @@ function M.find_lsp_path(basePath, is_dll)
     local path = ""
     local os_name = vim.uv.os_uname().sysname:lower()
     local sep = os_name:match("windows") and "\\" or "/"
-    local binary_folder = sep .. "bin" .. sep .. (os_name:match("windows") and "win32" or "linux") .. sep
+    local platform = os_name:match("windows") and "win32" or os_name:match("darwin") and "darwin" or "linux"
+    local binary_folder = sep .. "bin" .. sep .. platform .. sep
 
     -- Expand ~ to full path
     local expanded_base = vim.fn.expand(basePath)

--- a/tests/al/lsp_spec.lua
+++ b/tests/al/lsp_spec.lua
@@ -1,0 +1,52 @@
+describe("al.lsp.find_lsp_path", function()
+    local lsp
+    local orig_uname, orig_scandir, orig_scandir_next, orig_expand
+
+    before_each(function()
+        package.loaded["al.lsp"] = nil
+        lsp = require("al.lsp")
+        orig_uname = vim.uv.os_uname
+        orig_scandir = vim.uv.fs_scandir
+        orig_scandir_next = vim.uv.fs_scandir_next
+        orig_expand = vim.fn.expand
+
+        -- Fake an extensions dir containing one AL extension folder.
+        vim.fn.expand = function(p) return p end
+        vim.uv.fs_scandir = function() return true end
+        local yielded = false
+        vim.uv.fs_scandir_next = function()
+            if yielded then return nil end
+            yielded = true
+            return "ms-dynamics-smb.al-15.0.0", "directory"
+        end
+    end)
+
+    after_each(function()
+        vim.uv.os_uname = orig_uname
+        vim.uv.fs_scandir = orig_scandir
+        vim.uv.fs_scandir_next = orig_scandir_next
+        vim.fn.expand = orig_expand
+    end)
+
+    local function stub_os(sysname)
+        vim.uv.os_uname = function() return { sysname = sysname, machine = "x86_64" } end
+    end
+
+    it("uses bin/darwin on macOS", function()
+        stub_os("Darwin")
+        local path = lsp.find_lsp_path("~/.vscode/extensions/", false)
+        assert.is_truthy(path:match("/bin/darwin/Microsoft%.Dynamics%.Nav%.EditorServices%.Host$"))
+    end)
+
+    it("uses bin/win32 with backslashes on Windows", function()
+        stub_os("Windows_NT")
+        local path = lsp.find_lsp_path("~\\.vscode\\extensions\\", false)
+        assert.is_truthy(path:match("\\bin\\win32\\Microsoft%.Dynamics%.Nav%.EditorServices%.Host$"))
+    end)
+
+    it("uses bin/linux on Linux", function()
+        stub_os("Linux")
+        local path = lsp.find_lsp_path("~/.vscode/extensions/", true)
+        assert.is_truthy(path:match("/bin/linux/Microsoft%.Dynamics%.Nav%.EditorServices%.Host%.dll$"))
+    end)
+end)


### PR DESCRIPTION
Closes #12

## Problem

`find_lsp_path` mapped every non-Windows OS to the `bin/linux` binary folder, so the AL EditorServices host was never located on macOS. The default `vscodeExtensionsPath` was also a Windows-only backslash path.

## Changes

- `lua/al/lsp.lua` — add a `darwin` branch to the platform selection so macOS resolves `bin/darwin/Microsoft.Dynamics.Nav.EditorServices.Host`.
- `lua/al/config.lua` — OS-aware default `vscodeExtensionsPath` (`~/.vscode/extensions/` on Unix, backslash form on Windows).
- `tests/al/lsp_spec.lua` — cover win32 / darwin / linux path resolution.

The debug proxy already resolved darwin targets (`debugger.lua`, `dap.lua`); this brings LSP path resolution in line. Removes the need for the `find_lsp_path` override workaround posted in the issue.

## Test

Full suite passes (`nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/ ..."`), 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)