### PR TITLE
feat: :AL debugWithoutPublishing (debug without publishing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,30 +114,38 @@ jobs:
                       COMMITS=$(git log ${LATEST_TAG}..HEAD --pretty=format:"%s" --reverse)
                   fi
 
-                  # Parse conventional commits
-                  echo "$COMMITS" | while IFS= read -r commit; do
+                  # Parse conventional commits into per-category bucket files,
+                  # so each header is emitted once with all its bullets grouped.
+                  BUCKET_DIR=$(mktemp -d)
+                  while IFS= read -r commit; do
                       if [[ $commit =~ ^feat(\(.+\))?!?: ]]; then
-                          echo "### ✨ Features" >> CHANGELOG.md
-                          echo "- ${commit#feat*: }" >> CHANGELOG.md
-                          echo "" >> CHANGELOG.md
+                          echo "- ${commit#feat*: }" >> "$BUCKET_DIR/feat"
                       elif [[ $commit =~ ^fix(\(.+\))?: ]]; then
-                          echo "### 🐛 Bug Fixes" >> CHANGELOG.md
-                          echo "- ${commit#fix*: }" >> CHANGELOG.md
-                          echo "" >> CHANGELOG.md
+                          echo "- ${commit#fix*: }" >> "$BUCKET_DIR/fix"
                       elif [[ $commit =~ ^docs(\(.+\))?: ]]; then
-                          echo "### 📚 Documentation" >> CHANGELOG.md
-                          echo "- ${commit#docs*: }" >> CHANGELOG.md
-                          echo "" >> CHANGELOG.md
+                          echo "- ${commit#docs*: }" >> "$BUCKET_DIR/docs"
                       elif [[ $commit =~ ^perf(\(.+\))?: ]]; then
-                          echo "### ⚡ Performance" >> CHANGELOG.md
-                          echo "- ${commit#perf*: }" >> CHANGELOG.md
-                          echo "" >> CHANGELOG.md
+                          echo "- ${commit#perf*: }" >> "$BUCKET_DIR/perf"
                       elif [[ $commit =~ ^refactor(\(.+\))?: ]]; then
-                          echo "### 🔧 Refactoring" >> CHANGELOG.md
-                          echo "- ${commit#refactor*: }" >> CHANGELOG.md
+                          echo "- ${commit#refactor*: }" >> "$BUCKET_DIR/refactor"
+                      fi
+                  done <<< "$COMMITS"
+
+                  # Emit each section once, in a fixed order, only if it has entries.
+                  emit_section() {
+                      local file="$1" heading="$2"
+                      if [ -s "$BUCKET_DIR/$file" ]; then
+                          echo "### $heading" >> CHANGELOG.md
+                          cat "$BUCKET_DIR/$file" >> CHANGELOG.md
                           echo "" >> CHANGELOG.md
                       fi
-                  done
+                  }
+                  emit_section feat "✨ Features"
+                  emit_section fix "🐛 Bug Fixes"
+                  emit_section perf "⚡ Performance"
+                  emit_section refactor "🔧 Refactoring"
+                  emit_section docs "📚 Documentation"
+                  rm -rf "$BUCKET_DIR"
 
                   # Check for breaking changes
                   if echo "$COMMITS" | grep -q "BREAKING CHANGE\|!:"; then

--- a/doc/al.txt
+++ b/doc/al.txt
@@ -183,6 +183,16 @@ All commands use the `:AL` prefix.
 :AL build           Build the AL package for the current workspace via the
                     language server.
 
+                                              *:AL-debugWithoutPublishing*
+:AL debugWithoutPublishing
+                    Start a debug session without publishing. Uses the
+                    active launch configuration (or prompts to select one)
+                    and debugs the app already deployed to the server —
+                    the local project is not rebuilt or republished.
+                    Publish first with F5 or your publish flow if the
+                    deployed app is out of date. Equivalent to VS Code's
+                    "AL: Debug without publishing".
+
                                                     *:AL-downloadSymbols*
 :AL downloadSymbols Download AL symbol packages. Prompts for a launch
                     configuration if multiple are defined in launch.json.

--- a/lua/al/cmd.lua
+++ b/lua/al/cmd.lua
@@ -94,6 +94,11 @@ M.commands = {
             require("al.editor_commands.publish")(config)
         end)
     end,
+    debugWithoutPublishing = function()
+        with_config(function(config)
+            require("al.editor_commands.debug_without_publishing")(config)
+        end)
+    end,
     downloadSymbols = function()
         with_config(function(config)
             require("al.editor_commands.download_symbols")(config)

--- a/lua/al/editor_commands/debug_without_publishing.lua
+++ b/lua/al/editor_commands/debug_without_publishing.lua
@@ -1,0 +1,24 @@
+local Util = require("al.utils")
+
+--- Start a debug session against the already-deployed app, skipping the
+--- local build + publish step (VS Code: "AL: Debug without publishing").
+--- `config` is a launch configuration already merged with default_launch_cfg.
+---@param config al.LaunchConfiguration
+local debug_without_publishing = function(config)
+    local ok, dap = pcall(require, "dap")
+    if not ok then
+        Util.error("nvim-dap is not available.")
+        return
+    end
+
+    local cfg = vim.tbl_extend("force", config, {
+        justDebug = true,
+        publishOnly = false,
+        isRad = false,
+        request = "launch",
+    })
+
+    dap.run(cfg)
+end
+
+return debug_without_publishing

--- a/lua/al/integrations/dap.lua
+++ b/lua/al/integrations/dap.lua
@@ -24,7 +24,9 @@ function M.setup()
             Util.error("Authentication failed: " .. auth_result)
         end
 
-        build_package()
+        if M.should_build(config) then
+            build_package()
+        end
 
         callback({
             type = "executable",
@@ -71,6 +73,14 @@ function M.setup()
             validateServerCertificate = true,
         },
     }
+end
+
+--- Whether to build the package before debugging. Skipped for
+--- "debug without publishing" (justDebug), which debugs the deployed app.
+---@param config table
+---@return boolean
+function M.should_build(config)
+    return not config.justDebug
 end
 
 function M.cmd()

--- a/tests/al/cmd_spec.lua
+++ b/tests/al/cmd_spec.lua
@@ -66,7 +66,9 @@ describe("al.cmd", function()
             local notified = false
             local orig = vim.notify
             vim.notify = function(msg)
-                if msg:match("Usage:") then notified = true end
+                if msg:match("Usage:") then
+                    notified = true
+                end
             end
             cmd.execute({ args = "" })
             assert.is_true(notified)
@@ -77,7 +79,9 @@ describe("al.cmd", function()
             local notified = false
             local orig = vim.notify
             vim.notify = function(msg)
-                if msg:match("Unknown command") then notified = true end
+                if msg:match("Unknown command") then
+                    notified = true
+                end
             end
             cmd.execute({ args = "nonexistent" })
             assert.is_true(notified)
@@ -86,16 +90,31 @@ describe("al.cmd", function()
 
         it("calls correct command handler", function()
             local called = false
-            cmd.commands.definition = function() called = true end
+            cmd.commands.definition = function()
+                called = true
+            end
             cmd.execute({ args = "definition" })
             assert.is_true(called)
         end)
 
         it("passes args to command handler", function()
             local received_args
-            cmd.commands.symbolSearch = function(args) received_args = args end
+            cmd.commands.symbolSearch = function(args)
+                received_args = args
+            end
             cmd.execute({ args = "symbolSearch Customer" })
             assert.are.same({ "Customer" }, received_args)
+        end)
+    end)
+
+    describe("debugWithoutPublishing", function()
+        it("is a registered command", function()
+            assert.is_function(cmd.commands.debugWithoutPublishing)
+        end)
+
+        it("is offered by completion", function()
+            local matches = cmd.complete("debug", "AL debug")
+            assert.is_true(vim.tbl_contains(matches, "debugWithoutPublishing"))
         end)
     end)
 end)

--- a/tests/al/editor_commands/debug_without_publishing_spec.lua
+++ b/tests/al/editor_commands/debug_without_publishing_spec.lua
@@ -1,0 +1,60 @@
+local helpers = require("tests.helpers")
+
+describe("al.editor_commands.debug_without_publishing", function()
+    local mod
+
+    before_each(function()
+        package.loaded["al.editor_commands.debug_without_publishing"] = nil
+    end)
+
+    after_each(function()
+        package.loaded["dap"] = nil
+    end)
+
+    it("runs dap with justDebug overlay, preserving connection fields", function()
+        local captured
+        package.loaded["dap"] = {
+            run = function(cfg)
+                captured = cfg
+            end,
+        }
+        mod = require("al.editor_commands.debug_without_publishing")
+
+        mod({
+            name = "Dev",
+            server = "http://bc",
+            serverInstance = "BC",
+            tenant = "default",
+            startupObjectId = 42,
+        })
+
+        assert.is_not_nil(captured)
+        assert.is_true(captured.justDebug)
+        assert.is_false(captured.publishOnly)
+        assert.is_false(captured.isRad)
+        assert.are.equal("launch", captured.request)
+        assert.are.equal("http://bc", captured.server)
+        assert.are.equal("BC", captured.serverInstance)
+        assert.are.equal("default", captured.tenant)
+        assert.are.equal(42, captured.startupObjectId)
+    end)
+
+    it("errors gracefully when nvim-dap is unavailable", function()
+        package.loaded["dap"] = nil
+        mod = require("al.editor_commands.debug_without_publishing")
+        local notify = helpers.capture_notify()
+
+        assert.has_no.errors(function()
+            mod({ name = "Dev" })
+        end)
+
+        local found = false
+        for _, m in ipairs(notify.messages) do
+            if m.msg:match("nvim%-dap is not available") then
+                found = true
+            end
+        end
+        assert.is_true(found)
+        notify.restore()
+    end)
+end)

--- a/tests/al/integrations/dap_spec.lua
+++ b/tests/al/integrations/dap_spec.lua
@@ -1,0 +1,20 @@
+describe("al.integrations.dap.should_build", function()
+    local dap_int
+
+    before_each(function()
+        package.loaded["al.integrations.dap"] = nil
+        dap_int = require("al.integrations.dap")
+    end)
+
+    it("skips build when justDebug is true", function()
+        assert.is_false(dap_int.should_build({ justDebug = true }))
+    end)
+
+    it("builds when justDebug is false", function()
+        assert.is_true(dap_int.should_build({ justDebug = false }))
+    end)
+
+    it("builds when justDebug is absent", function()
+        assert.is_true(dap_int.should_build({}))
+    end)
+end)


### PR DESCRIPTION
## Summary

Adds `:AL debugWithoutPublishing` — the Neovim equivalent of VS Code's **AL: Debug without publishing** (`al.onlyDebug`). Starts a debug session against the **already-deployed** app, skipping the local build + publish.

Reverse-engineered from the AL extension: this is *not* a new config type or the `attach` request — it's the normal launch config + `justDebug=true`, with the local build skipped. `justDebug` forces `publishOnly=false`/`isRad=false` (matches the extension).

## How it works

- **`lua/al/editor_commands/debug_without_publishing.lua`** (new) — takes the resolved launch config, overlays `{justDebug=true, publishOnly=false, isRad=false, request="launch"}` (runtime-only, never written to `launch.json`), calls `dap.run`.
- **`lua/al/cmd.lua`** — new `debugWithoutPublishing` command; reuses the existing `with_config` env resolution (`State.active_config`, or picker if none set) — same environment selection as `:AL publish`/`build`.
- **`lua/al/integrations/dap.lua`** — `should_build(config)` seam; the dap adapter skips `build_package()` when `justDebug` is set. Auth still runs. Normal F5 path unchanged (no `justDebug` → still builds).
- **`doc/al.txt`** — documents the command + the already-deployed caveat.

## Also included

- **`fix(release)`** — group changelog entries under one `###` header per category instead of repeating the header per commit. Unrelated to the feature; bundled at request.

## Testing

- New tests: `should_build` (true/false/absent), config overlay + connection-field preservation, graceful dap-missing path.
- Lint: `luacheck` 0 warnings / 0 errors. Full suite: 21 files, 0 failures.
- ⚠️ **Not verified end-to-end** against a live Business Central server (needs infra). Manual check before relying on it: set a breakpoint, run `:AL debugWithoutPublishing`, confirm no publish occurs and the breakpoint hits.

## Semantics / caveat

Debugs what's already deployed — local source is not recompiled/republished. Publish first (F5 / `:AL publish`) if the deployed app is stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)