### PR TITLE
feat: add :checkhealth al

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,15 @@ multi-project workspaces for Microsoft Dynamics 365 Business Central.
 
 ## Requirements
 
-- Neovim >= 0.10
+- Neovim >= 0.11
 - [Microsoft AL Language Extension] for VS Code (provides the language server
   binary)
+
+## Health check
+
+Run `:checkhealth al` to diagnose your setup — it checks your Neovim version,
+the AL language server (VS Code AL extension), the debug proxy, `dotnet` and
+the AL compiler tool, and optional integrations.
 
 ## Installation
 

--- a/doc/al.txt
+++ b/doc/al.txt
@@ -11,6 +11,7 @@ CONTENTS                                                          *al-contents*
   6. Integrations ..................................... |al-integrations|
   7. Multi-project workspaces ......................... |al-multiproject|
   8. Debugger ......................................... |al-debugger|
+  9. Health check ..................................... |al-health|
 
 ==============================================================================
 1. INTRODUCTION                                               *al-introduction*
@@ -30,7 +31,7 @@ Features:
 2. REQUIREMENTS                                               *al-requirements*
 
 Required:
-  - Neovim >= 0.10
+  - Neovim >= 0.11
   - Microsoft AL Language Extension for VS Code (provides the language server)
   - nui.nvim        UI for auth and symbol download menus
   - nvim-nio        async I/O for multi-project and debugging
@@ -339,6 +340,21 @@ Building from source (requires Go 1.21+): >bash
 <
 
 Refer to |nvim-dap| for how to start and control debug sessions.
+
+==============================================================================
+9. HEALTH CHECK                                                     *al-health*
+
+Run `:checkhealth al` to diagnose your installation. It reports:
+
+  - Neovim version (0.11+ required)
+  - AL Language Server binary (from the VS Code AL extension)
+  - Debug proxy binary
+  - `dotnet` and the AL compiler tool (`al`) on PATH
+  - Optional integrations (nvim-dap, LuaSnip, nvim-treesitter + `al` parser)
+  - Whether the current directory is inside an AL project
+
+Errors point at what is missing; warnings mark optional pieces. See
+|al-requirements| for what each item needs.
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:

--- a/lua/al/health.lua
+++ b/lua/al/health.lua
@@ -1,6 +1,10 @@
 -- lua/al/health.lua
 local M = {}
 
+local Config = require("al.config")
+local Lsp = require("al.lsp")
+local Dap = require("al.integrations.dap")
+
 local h = vim.health
 
 --- Report the Neovim version. 0.11 is the effective floor because
@@ -14,6 +18,64 @@ local function check_nvim()
             "Neovim 0.11+ required (LSP setup uses vim.lsp.config/enable with no fallback); found "
                 .. tostring(vim.version())
         )
+    end
+end
+
+--- Resolve the AL Language Server binary via the VS Code AL extension.
+--- find_lsp_path does NOT stat the file, so stat it here to catch a matched
+--- extension folder with a missing/renamed binary (a silent failure today).
+local function check_lsp_server()
+    h.start("AL language server (VS Code AL extension)")
+    local base = Config.vscodeExtensionsPath
+    local bin = Lsp.find_lsp_path(base, false)
+    if not bin then
+        h.error("AL extension not found under " .. vim.fn.expand(base), {
+            "Install the 'AL Language' (ms-dynamics-smb.al) VS Code extension",
+            "Or set vscodeExtensionsPath in setup()",
+        })
+        return
+    end
+    if vim.uv.fs_stat(bin) then
+        h.ok(("AL extension v%s\n  server: %s"):format(tostring(Config.language_extension_version), bin))
+    else
+        h.error("AL extension folder found but server binary missing: " .. bin)
+    end
+end
+
+--- The Go debug proxy is optional (only debugging needs it).
+local function check_debug_proxy()
+    h.start("Debug proxy")
+    local proxy = Dap.get_proxy_path()
+    if vim.fn.filereadable(proxy) == 1 then
+        h.ok("proxy binary: " .. proxy)
+    else
+        h.warn("Debug proxy binary not found: " .. proxy, {
+            "Build it: cd al.nvim/proxy-src && build.bat (Windows) or ./build.sh (Unix)",
+            "Only affects debugging; LSP and build work without it",
+        })
+    end
+end
+
+--- dotnet: needed by the debug proxy (execs `dotnet <EditorServices>.dll`)
+--- and by the AL compiler tool. LSP host is a native exe and does not need it.
+--- `al`: the AL compiler shipped as a dotnet global tool.
+local function check_external_tools()
+    h.start("External tools")
+
+    if vim.fn.executable("dotnet") == 1 then
+        h.ok("dotnet on PATH")
+    else
+        h.warn("dotnet not on PATH", { "Needed for debugging and the AL compiler tool; not needed for LSP" })
+    end
+
+    -- ponytail: bare name match on `al`; `al` is a common command name so a
+    -- false positive is possible. Upgrade to parsing `al help` only if it bites.
+    if vim.fn.executable("al") == 1 then
+        h.ok("AL compiler tool (`al`) on PATH")
+    else
+        h.warn("AL compiler tool (`al`) not on PATH", {
+            "Install: dotnet tool install --global Microsoft.Dynamics.BusinessCentral.Development.Tools",
+        })
     end
 end
 
@@ -31,6 +93,9 @@ end
 
 function M.check()
     check_nvim()
+    check_lsp_server()
+    check_debug_proxy()
+    check_external_tools()
     check_workspace()
 end
 

--- a/lua/al/health.lua
+++ b/lua/al/health.lua
@@ -68,10 +68,20 @@ local function check_external_tools()
         h.warn("dotnet not on PATH", { "Needed for debugging and the AL compiler tool; not needed for LSP" })
     end
 
-    -- ponytail: bare name match on `al`; `al` is a common command name so a
-    -- false positive is possible. Upgrade to parsing `al help` only if it bites.
+    -- `al` collides with the .NET Framework Assembly Linker (al.exe), common on
+    -- Windows dev boxes. Disambiguate via `al --version`: the BC AL CLI prints a
+    -- bare semver as its first line; the Assembly Linker prints a "Microsoft (R)
+    -- ... Assembly Linker" banner that does not start with a digit.
     if vim.fn.executable("al") == 1 then
-        h.ok("AL compiler tool (`al`) on PATH")
+        local first = vim.trim((vim.fn.system({ "al", "--version" }) or ""):match("^[^\r\n]*") or "")
+        if first:match("^%d+%.%d+%.%d+") then
+            h.ok("AL compiler tool (`al`) v" .. first)
+        else
+            h.warn("`al` on PATH is not the BC AL compiler (Assembly Linker?): " .. first, {
+                "Expected Microsoft.Dynamics.BusinessCentral.Development.Tools",
+                "Install: dotnet tool install --global Microsoft.Dynamics.BusinessCentral.Development.Tools",
+            })
+        end
     else
         h.warn("AL compiler tool (`al`) not on PATH", {
             "Install: dotnet tool install --global Microsoft.Dynamics.BusinessCentral.Development.Tools",

--- a/lua/al/health.lua
+++ b/lua/al/health.lua
@@ -146,16 +146,27 @@ local function check_workspace()
     local ok_mp, mp = pcall(require, "al.multiproject")
     local ws = ok_mp and mp.workspace_root() or nil
     if ws then
-        local al_root = mp.lsp_root_dir()
-        if al_root then
-            h.ok(
-                ("multi-project workspace active: %s\n  AL project root: %s"):format(
-                    vim.fs.normalize(ws),
-                    vim.fs.normalize(al_root)
-                )
+        local folders = mp.workspace_folders() or {}
+        h.ok(
+            ("multi-project workspace active: %s (%d folder%s)"):format(
+                vim.fs.normalize(ws),
+                #folders,
+                #folders == 1 and "" or "s"
             )
-        else
-            h.warn("multi-project workspace active but no folder contains app.json: " .. vim.fs.normalize(ws))
+        )
+        local al_count = 0
+        for _, f in ipairs(folders) do
+            local path = vim.fs.normalize(f.path)
+            local name = f.name or vim.fs.basename(path)
+            if (vim.uv.fs_stat(f.path .. "/app.json") or {}).type == "file" then
+                al_count = al_count + 1
+                h.ok(("  %s: %s"):format(name, path))
+            else
+                h.info(("  %s: %s (no app.json)"):format(name, path))
+            end
+        end
+        if al_count == 0 then
+            h.warn("no workspace folder contains app.json")
         end
         return
     end

--- a/lua/al/health.lua
+++ b/lua/al/health.lua
@@ -37,10 +37,14 @@ local function check_lsp_server()
         })
         return
     end
-    if vim.uv.fs_stat(bin) then
-        h.ok(("AL extension v%s\n  server: %s"):format(tostring(Config.language_extension_version), bin))
+    -- On Windows find_lsp_path returns the host WITHOUT the `.exe` that libuv
+    -- appends when it spawns the LSP, so stat both names or we false-negative.
+    local exists = vim.uv.fs_stat(bin) or (vim.fn.has("win32") == 1 and vim.uv.fs_stat(bin .. ".exe"))
+    local shown = vim.fs.normalize(bin)
+    if exists then
+        h.ok(("AL extension v%s\n  server: %s"):format(tostring(Config.language_extension_version), shown))
     else
-        h.error("AL extension folder found but server binary missing: " .. bin, {
+        h.error("AL extension folder found but server binary missing: " .. shown, {
             "Reinstall the 'AL Language' (ms-dynamics-smb.al) VS Code extension",
         })
     end

--- a/lua/al/health.lua
+++ b/lua/al/health.lua
@@ -1,0 +1,37 @@
+-- lua/al/health.lua
+local M = {}
+
+local h = vim.health
+
+--- Report the Neovim version. 0.11 is the effective floor because
+--- vim.lsp.config / vim.lsp.enable (lsp.lua) have no pre-0.11 fallback.
+local function check_nvim()
+    h.start("Neovim")
+    if vim.fn.has("nvim-0.11") == 1 then
+        h.ok("Neovim " .. tostring(vim.version()))
+    else
+        h.error(
+            "Neovim 0.11+ required (LSP setup uses vim.lsp.config/enable with no fallback); found "
+                .. tostring(vim.version())
+        )
+    end
+end
+
+--- Report whether the current directory / buffer sits inside an AL project.
+--- Informational only -- :checkhealth can be run from anywhere.
+local function check_workspace()
+    h.start("Workspace")
+    local root = vim.fs.root(0, { "app.json", ".alpackages" })
+    if root then
+        h.ok("AL project root: " .. root)
+    else
+        h.info("No AL project (app.json / .alpackages) found from the current directory")
+    end
+end
+
+function M.check()
+    check_nvim()
+    check_workspace()
+end
+
+return M

--- a/lua/al/health.lua
+++ b/lua/al/health.lua
@@ -25,6 +25,9 @@ end
 --- extension folder with a missing/renamed binary (a silent failure today).
 local function check_lsp_server()
     h.start("AL language server (VS Code AL extension)")
+    -- Reading Config respects the user's configured vscodeExtensionsPath. On a
+    -- not-yet-setup plugin this first Config access triggers config.lua's lazy
+    -- setup() (config.lua __index) -- intended; do not "fix" by hardcoding the default.
     local base = Config.vscodeExtensionsPath
     local bin = Lsp.find_lsp_path(base, false)
     if not bin then
@@ -111,7 +114,7 @@ local function check_integrations()
 
     -- treesitter: plugin present AND the `al` parser installed.
     -- NOTE: vim.treesitter.language.add returns `true` when the parser loads and
-    -- `nil` (no error thrown) when it is missing — so a bare `pcall(...)` truthiness
+    -- `nil` (no error thrown) when it is missing, so a bare `pcall(...)` truthiness
     -- test would false-OK. Check the RETURN value, not just that pcall didn't error.
     if not integ.treesitter then
         h.info("treesitter: disabled")

--- a/lua/al/health.lua
+++ b/lua/al/health.lua
@@ -1,4 +1,3 @@
--- lua/al/health.lua
 local M = {}
 
 local Config = require("al.config")
@@ -38,7 +37,9 @@ local function check_lsp_server()
     if vim.uv.fs_stat(bin) then
         h.ok(("AL extension v%s\n  server: %s"):format(tostring(Config.language_extension_version), bin))
     else
-        h.error("AL extension folder found but server binary missing: " .. bin)
+        h.error("AL extension folder found but server binary missing: " .. bin, {
+            "Reinstall the 'AL Language' (ms-dynamics-smb.al) VS Code extension",
+        })
     end
 end
 
@@ -112,10 +113,10 @@ local function check_integrations()
     -- NOTE: vim.treesitter.language.add returns `true` when the parser loads and
     -- `nil` (no error thrown) when it is missing — so a bare `pcall(...)` truthiness
     -- test would false-OK. Check the RETURN value, not just that pcall didn't error.
-    if integ.treesitter == false then
+    if not integ.treesitter then
         h.info("treesitter: disabled")
     elseif not pcall(require, "nvim-treesitter") then
-        h.warn("treesitter: 'nvim-treesitter' not installed")
+        h.warn("treesitter: 'nvim-treesitter' not installed", { "Install nvim-treesitter/nvim-treesitter" })
     else
         local ok, added = pcall(vim.treesitter.language.add, "al")
         if ok and added then

--- a/lua/al/health.lua
+++ b/lua/al/health.lua
@@ -134,13 +134,35 @@ local function check_integrations()
     end
 end
 
---- Report whether the current directory / buffer sits inside an AL project.
---- Informational only -- :checkhealth can be run from anywhere.
+--- Report the AL project context. In multi-project mode (a .code-workspace
+--- loaded via code-workspace.nvim) report the active workspace; otherwise look
+--- for a single app.json / .alpackages from the current buffer. Informational
+--- only -- :checkhealth can be run from anywhere.
 local function check_workspace()
     h.start("Workspace")
+
+    -- pcall: al.multiproject requires nio at load; degrade to the single-project
+    -- check if it (or its dep) is unavailable rather than erroring the report.
+    local ok_mp, mp = pcall(require, "al.multiproject")
+    local ws = ok_mp and mp.workspace_root() or nil
+    if ws then
+        local al_root = mp.lsp_root_dir()
+        if al_root then
+            h.ok(
+                ("multi-project workspace active: %s\n  AL project root: %s"):format(
+                    vim.fs.normalize(ws),
+                    vim.fs.normalize(al_root)
+                )
+            )
+        else
+            h.warn("multi-project workspace active but no folder contains app.json: " .. vim.fs.normalize(ws))
+        end
+        return
+    end
+
     local root = vim.fs.root(0, { "app.json", ".alpackages" })
     if root then
-        h.ok("AL project root: " .. root)
+        h.ok("AL project root: " .. vim.fs.normalize(root))
     else
         h.info("No AL project (app.json / .alpackages) found from the current directory")
     end

--- a/lua/al/health.lua
+++ b/lua/al/health.lua
@@ -89,6 +89,43 @@ local function check_external_tools()
     end
 end
 
+--- Verify each enabled integration's backing plugin is loadable.
+--- treesitter additionally needs the `al` parser installed.
+local function check_integrations()
+    h.start("Optional integrations")
+    local integ = Config.integrations or {}
+
+    local function report(enabled, name, mod, hint)
+        if not enabled then
+            h.info(name .. ": disabled")
+        elseif pcall(require, mod) then
+            h.ok(name .. ": " .. mod .. " loaded")
+        else
+            h.warn(name .. ": '" .. mod .. "' not installed", hint and { hint } or nil)
+        end
+    end
+
+    report(integ.dap, "dap", "dap", "Install nvim-dap for debugging")
+    report(integ.luasnip, "luasnip", "luasnip", "Install L3MON4D3/LuaSnip for snippets")
+
+    -- treesitter: plugin present AND the `al` parser installed.
+    -- NOTE: vim.treesitter.language.add returns `true` when the parser loads and
+    -- `nil` (no error thrown) when it is missing — so a bare `pcall(...)` truthiness
+    -- test would false-OK. Check the RETURN value, not just that pcall didn't error.
+    if integ.treesitter == false then
+        h.info("treesitter: disabled")
+    elseif not pcall(require, "nvim-treesitter") then
+        h.warn("treesitter: 'nvim-treesitter' not installed")
+    else
+        local ok, added = pcall(vim.treesitter.language.add, "al")
+        if ok and added then
+            h.ok("treesitter: nvim-treesitter loaded, `al` parser installed")
+        else
+            h.warn("treesitter: `al` parser not installed", { "Run :TSUpdate al (parser: SShadowS/tree-sitter-al)" })
+        end
+    end
+end
+
 --- Report whether the current directory / buffer sits inside an AL project.
 --- Informational only -- :checkhealth can be run from anywhere.
 local function check_workspace()
@@ -106,6 +143,7 @@ function M.check()
     check_lsp_server()
     check_debug_proxy()
     check_external_tools()
+    check_integrations()
     check_workspace()
 end
 

--- a/lua/al/multiproject.lua
+++ b/lua/al/multiproject.lua
@@ -559,6 +559,13 @@ function M.workspace_root()
     return _workspace_root
 end
 
+--- Returns the workspace folder list ({ path, name }) when a multi-project
+--- workspace is active, else nil.
+---@return table[]|nil
+function M.workspace_folders()
+    return _workspace and _workspace.folders or nil
+end
+
 --- Returns the root directory for the AL LS client in multi-project mode.
 --- Uses the first AL project folder (with app.json) instead of the workspace
 --- parent directory, because the AL server expects rootPath/rootUri to point


### PR DESCRIPTION
## What

Adds `:checkhealth al` — a health check so users can self-diagnose a broken
al.nvim setup instead of hitting silent failures (today the LSP setup returns
with no notification when the AL server binary can't be found).

New module `lua/al/health.lua` (`M.check()`, auto-discovered by Neovim — no
registration). It reuses existing detection (`Lsp.find_lsp_path`,
`Dap.get_proxy_path`) rather than duplicating path logic, and reports via the
native `vim.health` API.

### Sections reported
- **Neovim** — ERROR below 0.11 (`vim.lsp.config`/`vim.lsp.enable` are 0.11-only, no fallback)
- **AL language server** — resolves the VS Code AL extension and `fs_stat`s the `EditorServices.Host` binary (the plugin never stats it today → silent failure; this closes that gap)
- **Debug proxy** — WARN if the bundled binary is missing (debug-only)
- **External tools** — `dotnet` + the AL compiler tool `al`
- **Optional integrations** — nvim-dap / LuaSnip / nvim-treesitter (+ the `al` parser)
- **Workspace** — INFO on whether cwd is inside an AL project

### Notable decisions
- **`al` disambiguation:** `al.exe` is also the .NET Framework Assembly Linker (common on Windows dev boxes). A bare `executable("al")` would false-OK. The check runs `al --version` and requires a semver first line — the BC AL CLI prints a bare semver, the Assembly Linker prints a "Microsoft (R) … Assembly Linker" banner. Verified against the real tool (`18.0.39.10160`).
- **Docs also bump the stated Neovim floor 0.10 → 0.11** in README + `doc/al.txt`, matching what the health check enforces and what the LSP actually requires.
- **No unit-test framework** — the module is I/O-bound environment detection; verification is a headless `:checkhealth al` run + luacheck + stylua (YAGNI).

## Verification
- `luacheck lua/al/health.lua` → 0/0; `stylua --check lua/al/health.lua` → clean
- Headless `:checkhealth al` renders all six sections with no Lua errors (good and broken setups)
- `:help al-health` resolves (helptags regenerated; `doc/tags` is gitignored)

## Follow-ups (non-blocking, from final review)
- Reading `Config` in `check_lsp_server` triggers config.lua's lazy `setup()` on a not-yet-setup plugin (pre-existing `__index` behavior; benign in production). A read-only config accessor would let a health check avoid mutating editor state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)