### PR TITLE
fix(lsp): make go-to-definition work with the AL server's custom protocol

### DIFF
--- a/lua/al/buf.lua
+++ b/lua/al/buf.lua
@@ -50,6 +50,16 @@ M.on_attach = function(client, buf)
 
     Lsp.attach(client)
 
+    -- Neovim's built-in tagfunc (which backs <C-]>) is synchronous with a
+    -- hardcoded 1000ms timeout, but the AL server's first go-to-definition
+    -- lookup for a symbol can take several seconds. Bind <C-]> directly to
+    -- the async go_to_definition instead.
+    vim.keymap.set("n", "<C-]>", Lsp.go_to_definition, {
+        buffer = buf,
+        silent = true,
+        desc = "al: Go to definition",
+    })
+
     if not require("al.multiproject").workspace_root() and not Workspace.is_active(client, buf) then
         Workspace.set_active(client, buf)
     end

--- a/lua/al/lsp.lua
+++ b/lua/al/lsp.lua
@@ -27,10 +27,29 @@ function M.attach(client)
 
     M.attached[client.id] = client.id
 
+    -- The AL server implements go-to-definition via a custom al/gotodefinition
+    -- method and never advertises definitionProvider (mirroring how VS
+    -- Code's AL extension registers its own DefinitionProvider client-side).
+    -- Already set in M.setup()'s on_init (early enough for _set_defaults'
+    -- tagfunc wiring); this is a harmless re-assertion for direct callers.
+    client.server_capabilities.definitionProvider = true
+
     -- The AL Language Server sends CompletionItem.label as {label: string}
     -- instead of a plain string. Normalize before any completion plugin sees it.
     local orig_request = client.request
     client.request = function(self, method, params, callback, ...)
+        if method == "textDocument/definition" and callback then
+            local body = {
+                configuration = nil,
+                browserInfo = {
+                    browser = Config.lsp.browser,
+                    incognito = Config.lsp.incognito,
+                },
+                environmentInfo = {},
+                textDocumentPositionParams = params,
+            }
+            return orig_request(self, "al/gotodefinition", body, callback, ...)
+        end
         if method == "textDocument/completion" and callback then
             local wrapped = function(err, result, ...)
                 if result then
@@ -142,6 +161,12 @@ function M.setup()
         end,
         single_file_support = true,
         settings = Config.workspace,
+        -- Must be set from on_init, not an LspAttach handler: Neovim's
+        -- lsp._set_defaults (tagfunc wiring for <C-]>) runs synchronously
+        -- in on_attach, before LspAttach fires.
+        on_init = function(client)
+            client.server_capabilities.definitionProvider = true
+        end,
         -- init_options = {
         --     logging = { level = "trace" },
         --     trace = { server = "verbose" },

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -10,6 +10,7 @@ function M.make_mock_client(opts)
         name = "al_ls",
         offset_encoding = "utf-16",
         handlers = {},
+        server_capabilities = {},
         requests = {},
         request = function(self, method, params, cb)
             table.insert(self.requests, { method = method, params = params })


### PR DESCRIPTION
## Summary

The AL Language Server implements go-to-definition via a custom `al/gotodefinition` method instead of standard LSP `textDocument/definition`, and never advertises `definitionProvider` (mirroring how VS Code's AL extension registers its own `DefinitionProvider` client-side rather than relying on LSP capability negotiation). This broke three separate things:

1. Telescope's `lsp_definitions`/`lsp_references`, `vim.lsp.buf.definition()`, and any other standard consumer reported "server does not support textDocument/definition" and never jumped.
2. Neovim's built-in tagfunc auto-binding (`lsp._set_defaults`, which backs `<C-]>`) only runs if the server advertises `definitionProvider` — since it never did, `<C-]>` always fell through to Vim's native `:tag`/ctags lookup and failed.
3. Even once `definitionProvider` is advertised, `<C-]>`'s tagfunc path is *synchronous* with a hardcoded 1000ms timeout — but the AL server's first ("cold") lookup for any given base-application/system symbol commonly takes several seconds (subsequent lookups are server-cached and fast). So `<C-]>` kept intermittently failing on any symbol not already cached.

Fixes:

- `M.attach`'s `client.request` wrapper now rewrites `textDocument/definition` requests into the `al/gotodefinition` body shape transparently, so standard consumers work unmodified.
- `M.setup`'s `al_ls` client config sets `client.server_capabilities.definitionProvider = true` from `on_init`, which runs before `on_attach` — setting it from an `LspAttach` handler instead would be one event-loop tick too late for `_set_defaults`' tagfunc decision.
- `M.on_attach` binds `<C-]>` directly to the existing (async) `go_to_definition` helper, bypassing the synchronous tagfunc path entirely.

All three fixes are needed together — each was discovered only once the prior one was resolved, so they're kept as a single commit rather than split into independently-incomplete pieces.