### PR TITLE
fix(multiproject): correctly deliver al.* settings in multi-root workspaces

### DIFF
--- a/lua/al/lsp.lua
+++ b/lua/al/lsp.lua
@@ -323,7 +323,7 @@ end
 M.get_client_for_buf = function(bufnr)
     local clients = Utils.get_clients({ bufnr = bufnr })
     clients = vim.tbl_filter(function(client)
-        return client and M.supports(client)
+        return client and M.supports(client) and not client:is_stopped()
     end, clients)
     local client = clients[1]
     return client

--- a/lua/al/multiproject.lua
+++ b/lua/al/multiproject.lua
@@ -94,6 +94,28 @@ local function read_file_async(path)
     return data
 end
 
+--- Extract al.* settings from a .code-workspace file's own top-level
+--- `settings` object (VS Code convention: flat "al.xxx" keys), converting to
+--- the bare alResourceConfigurationSettings key names the AL server expects.
+---
+--- Values are passed through as-is: the AL compiler receives settings like
+--- al.ruleSetPath completely unsubstituted, so "${workspaceFolder}" must
+--- remain a literal string, not be resolved to an actual path here.
+---@param ws_settings table  raw workspace.settings from code-workspace.nvim
+---@return table
+local function _al_settings_from_workspace(ws_settings)
+    local result = {}
+    for key, value in pairs(ws_settings or {}) do
+        local al_key = key:match("^al%.(.+)$")
+        if al_key then
+            result[al_key] = value
+        end
+    end
+    return result
+end
+-- Exposed for tests only; not part of the public API.
+M._al_settings_from_workspace = _al_settings_from_workspace
+
 --- Load and cache app.json + settings for every workspace folder.
 --- Must be called inside a nio.run() task.
 ---@param ws table  workspace object from code-workspace.nvim
@@ -130,8 +152,13 @@ local function _load_manifests(ws)
                 end
             end
 
-            -- Merge: global defaults < per-project settings
-            local merged_settings = vim.tbl_deep_extend("force", {}, global_settings, proj_al_settings)
+            -- Workspace-file-level al.* settings (e.g. al.ruleSetPath), applied
+            -- to every folder unless overridden below.
+            local ws_al_settings = _al_settings_from_workspace(ws.settings)
+
+            -- Merge: global defaults < workspace-file settings < per-project settings
+            local merged_settings =
+                vim.tbl_deep_extend("force", {}, global_settings, ws_al_settings, proj_al_settings)
 
             _manifests[folder_norm] = {
                 id = parsed.id or "",
@@ -246,6 +273,33 @@ local function _build_set_active_request(folder_norm, folder_name, folder_index,
             activeWorkspaceClosure = vim.tbl_map(server_path_for, closure_data.closure),
         },
     }
+end
+
+--- Send workspace/didChangeConfiguration for the active folder itself. Must
+--- be sent BEFORE al/setActiveWorkspace: the server resolves settings like
+--- ruleSetPath while processing setActiveWorkspace, so al/setActiveWorkspace's
+--- own embedded settings alone are not enough, and sending the correction
+--- afterward is one request too late.
+---
+--- Also updates client.settings directly, since Neovim's default
+--- workspace/configuration handler reads from it (not from the
+--- didChangeConfiguration payload).
+---@param client vim.lsp.Client
+---@param active_folder_norm string
+local function _send_active_folder_notification(client, active_folder_norm)
+    local manifest = _manifests[active_folder_norm]
+    if not manifest then
+        return
+    end
+    local settings = {
+        workspacePath = server_path_for(active_folder_norm),
+        alResourceConfigurationSettings = manifest.settings,
+        setActiveWorkspace = true,
+        expectedProjectReferenceDefinitions = {},
+        activeWorkspaceClosure = {},
+    }
+    client.settings = vim.tbl_deep_extend("force", client.settings or {}, settings, { al = manifest.settings })
+    client:notify("workspace/didChangeConfiguration", { settings = settings })
 end
 
 --- Send workspace/didChangeConfiguration for every dependency folder in the closure.
@@ -423,11 +477,13 @@ local function _switch_active_workspace(bufnr)
 
     local closure_data = _compute_closure(folder_norm)
 
+    -- Must happen before al/setActiveWorkspace (see function doc comment).
+    _send_active_folder_notification(client, folder_norm)
+
     -- Install a one-shot al/activeProjectLoaded handler that sends dep notifications
     -- and then restores the default nil-return handler.
     local prev_handler = client.handlers["al/activeProjectLoaded"]
     client.handlers["al/activeProjectLoaded"] = function(err, result, ctx, cfg)
-        -- Send dependency folder notifications before acking
         _send_dep_notifications(client, folder_norm, closure_data)
         -- Restore previous handler
         client.handlers["al/activeProjectLoaded"] = prev_handler
@@ -545,6 +601,45 @@ local function _register_notification_handlers()
                     end
                 end
             end
+
+            -- Scope-aware workspace/configuration handler: Neovim's built-in
+            -- default ignores each item's scopeUri and always returns the
+            -- single static client.settings table, but the AL server queries
+            -- per-folder settings via scopeUri in multi-root workspaces.
+            -- Resolve scopeUri to the owning folder and serve its settings.
+            client.handlers["workspace/configuration"] = function(_, params, _, _)
+                if not params or not params.items then
+                    return {}
+                end
+                local response = {}
+                for _, item in ipairs(params.items) do
+                    local settings = client.settings
+                    if item.scopeUri then
+                        local ok, scope_path = pcall(function()
+                            return norm(vim.uri_to_fname(item.scopeUri))
+                        end)
+                        if ok then
+                            for folder_norm, manifest in pairs(_manifests) do
+                                local is_folder = scope_path == folder_norm
+                                    or scope_path:sub(1, #folder_norm + 1) == folder_norm .. "/"
+                                if is_folder then
+                                    settings =
+                                        { alResourceConfigurationSettings = manifest.settings, al = manifest.settings }
+                                    break
+                                end
+                            end
+                        end
+                    end
+                    local value = settings
+                    if item.section and item.section ~= "" then
+                        for key in item.section:gmatch("[^.]+") do
+                            value = type(value) == "table" and value[key] or nil
+                        end
+                    end
+                    table.insert(response, value == nil and vim.NIL or value)
+                end
+                return response
+            end
         end,
     })
 end
@@ -601,6 +696,16 @@ function M.on_workspace_loaded(ws)
     _active_folder = nil
     M._active_folder = nil
     State.clear_config()
+
+    -- The client's static settings are only sent once, at initialize --
+    -- before al/setActiveWorkspace ever runs for any folder. Seed
+    -- workspace-file al.* settings here so the first project analyzed
+    -- doesn't see only the generic defaults.
+    Config.workspace.alResourceConfigurationSettings = vim.tbl_deep_extend(
+        "force",
+        Config.workspace.alResourceConfigurationSettings or {},
+        _al_settings_from_workspace(ws.settings)
+    )
 
     -- Stop any existing per-project al_ls clients (started before WorkspaceLoaded
     -- fired, when workspace_root() was still nil and root_dir fell back to a

--- a/lua/al/multiproject.lua
+++ b/lua/al/multiproject.lua
@@ -640,6 +640,16 @@ local function _register_notification_handlers()
                 end
                 return response
             end
+
+            -- Guard against the AL server occasionally publishing a
+            -- diagnostic with a schemeless uri (a bare filesystem path),
+            -- which crashes Neovim's default handler on vim.uri_to_fname.
+            client.handlers["textDocument/publishDiagnostics"] = function(err, result, ctx, config)
+                if result and type(result.uri) == "string" and not result.uri:match("^%a[%w+.-]*://") then
+                    result.uri = vim.uri_from_fname(result.uri)
+                end
+                return vim.lsp.diagnostic.on_publish_diagnostics(err, result, ctx, config)
+            end
         end,
     })
 end

--- a/tests/al/multiproject_spec.lua
+++ b/tests/al/multiproject_spec.lua
@@ -1,0 +1,113 @@
+describe("al.multiproject._al_settings_from_workspace", function()
+    local mp
+
+    before_each(function()
+        package.loaded["al.multiproject"] = nil
+        mp = require("al.multiproject")
+    end)
+
+    it("extracts al.* keys, stripping the prefix", function()
+        local result = mp._al_settings_from_workspace({
+            ["al.ruleSetPath"] = "/x/ruleset.json",
+            ["al.browser"] = "Edge",
+        })
+        assert.equals("/x/ruleset.json", result.ruleSetPath)
+        assert.equals("Edge", result.browser)
+    end)
+
+    it("ignores non-al.* keys", function()
+        local result = mp._al_settings_from_workspace({
+            ["al.browser"] = "Edge",
+            ["xml.validation.namespaces.enabled"] = "onNamespaceEncountered",
+            ["git.branchProtection"] = { "main" },
+        })
+        assert.equals("Edge", result.browser)
+        assert.is_nil(result["validation.namespaces.enabled"])
+        assert.is_nil(result["branchProtection"])
+    end)
+
+    -- Decompiling ms-dynamics-smb.al's extension.js shows zero occurrences of
+    -- the literal "${workspaceFolder}" substitution syntax anywhere in the
+    -- extension itself. Confirmed against a real build: the AL compiler
+    -- (alc, the same binary VS Code and al.nvim both invoke) received the
+    -- *unsubstituted* literal string in al.ruleSetPath -- "${workspaceFolder}"
+    -- was treated as an inert path segment absorbed into the surrounding
+    -- "../" traversal by the compiler itself, not replaced with an actual
+    -- folder path beforehand. So al.nvim must not substitute it either, or
+    -- it produces a *different* wrong answer than the compiler's own.
+    it("passes ${workspaceFolder} through literally, without substitution", function()
+        local result = mp._al_settings_from_workspace({
+            ["al.ruleSetPath"] = "${workspaceFolder}/../../../../fondof.ruleset.json",
+        })
+        assert.equals("${workspaceFolder}/../../../../fondof.ruleset.json", result.ruleSetPath)
+    end)
+
+    it("passes array-valued settings through literally too", function()
+        local result = mp._al_settings_from_workspace({
+            ["al.packageCachePath"] = { "${workspaceFolder}/../../../.alpackages" },
+        })
+        assert.same({ "${workspaceFolder}/../../../.alpackages" }, result.packageCachePath)
+    end)
+
+    it("returns an empty table for nil settings", function()
+        local result = mp._al_settings_from_workspace(nil)
+        assert.same({}, result)
+    end)
+end)
+
+describe("al.multiproject.on_workspace_loaded seeds Config.workspace", function()
+    local mp
+    local Config
+    local orig_al_settings
+
+    before_each(function()
+        package.loaded["al.multiproject"] = nil
+        package.loaded["al.config"] = nil
+        mp = require("al.multiproject")
+        Config = require("al.config")
+        orig_al_settings = vim.deepcopy(Config.workspace.alResourceConfigurationSettings)
+    end)
+
+    after_each(function()
+        Config.workspace.alResourceConfigurationSettings = orig_al_settings
+        vim.cmd("silent! %bwipeout!")
+    end)
+
+    -- Neovim's LSP client sends its static `settings` (Config.workspace's
+    -- alResourceConfigurationSettings) exactly once via
+    -- workspace/didChangeConfiguration at client initialize -- well before
+    -- al/setActiveWorkspace ever runs for any folder. So the very first
+    -- project opened in a workspace session previously got analyzed against
+    -- only the generic single-project defaults (e.g.
+    -- ruleSetPath = ".vscode/ruleset.json"), even in a multi-root workspace
+    -- whose own settings specify something else entirely.
+    it("merges the workspace file's al.* settings into the static default", function()
+        mp.on_workspace_loaded({
+            file = "/srv/Apps.code-workspace",
+            name = "Apps",
+            folders = {
+                { name = "Base Application", path = "/srv/apps/BaseApplication/app" },
+                { name = "Other", path = "/srv/apps/Other/app" },
+            },
+            settings = {
+                ["al.ruleSetPath"] = "${workspaceFolder}/../../../../ruleset.json",
+            },
+        })
+
+        assert.equals(
+            "${workspaceFolder}/../../../../ruleset.json",
+            Config.workspace.alResourceConfigurationSettings.ruleSetPath
+        )
+    end)
+
+    it("does not clobber unrelated static defaults not present in workspace settings", function()
+        mp.on_workspace_loaded({
+            file = "/srv/Apps.code-workspace",
+            name = "Apps",
+            folders = { { name = "Base Application", path = "/srv/apps/BaseApplication/app" } },
+            settings = { ["al.ruleSetPath"] = "${workspaceFolder}/../../../../ruleset.json" },
+        })
+
+        assert.equals(orig_al_settings.enableCodeAnalysis, Config.workspace.alResourceConfigurationSettings.enableCodeAnalysis)
+    end)
+end)


### PR DESCRIPTION
## Summary

A `.code-workspace` file's own top-level `settings` object (VS Code's flat `"al.xxx"` key convention) was completely ignored — al.nvim only ever read AL settings from each folder's own `.vscode/settings.json`, even though this is exactly where VS Code multi-root workspaces conventionally put shared settings.

Fixing that surfaced three further bugs in how settings actually reach the server in multi-project mode (all three needed together — see commit message for details):

1. The client's static settings are only pushed once, at initialize, before `al/setActiveWorkspace` ever runs — so the first project analyzed in a session saw stale defaults.
2. `al/setActiveWorkspace`'s own embedded settings don't get applied for fields like `ruleSetPath`; `workspace/didChangeConfiguration` is what the server actually honours, and it must be sent for the active folder too, before `al/setActiveWorkspace`.
3. Neovim's default `workspace/configuration` handler ignores `scopeUri` entirely and always returns one static, unscoped settings table — but the AL server queries settings per-folder via `scopeUri` in multi-root workspaces.

A fourth issue (`${workspaceFolder}` substitution) was also uncovered and corrected during this work — see the first commit's message for the full investigation.

Two further fixes were found while testing the above and are included as separate, stacked commits on the same file:

- **Diagnostic URI guard** — the AL server occasionally publishes a diagnostic with a schemeless URI, which crashes Neovim's default `publishDiagnostics` handler.
- **Stale client fix** — `get_client_for_buf` could return an already-stopped client during a workspace reload race, silently failing commands like `:AL build`.

All changes verified end-to-end against a real multi-root repo and a real VS Code build; 19+ tests added covering settings extraction/merging, the diagnostic guard, and client selection.