### PR TITLE
fix(build): surface compiler errors on failed builds and tolerate JSONC in launch.json

### DIFF
--- a/lua/al/editor_commands/build.lua
+++ b/lua/al/editor_commands/build.lua
@@ -36,13 +36,14 @@ local build_package = function()
     Util.info("Started creating package...")
     client:request("al/createPackage", params, function(err, result)
         if not result then
+            Util.error("Failed creating AL package\r\n" .. vim.inspect(err))
             coroutine.resume(co)
             return
         end
         if result.success then
             Util.info("Success: The package is created")
         else
-            Util.error("Failed creating AL package\r\n" .. vim.inspect(err))
+            Util.error("Failed creating AL package\r\n" .. vim.inspect(result))
         end
         coroutine.resume(co)
     end)

--- a/lua/al/editor_commands/build.lua
+++ b/lua/al/editor_commands/build.lua
@@ -3,6 +3,17 @@ local Util = require("al.utils")
 local Workspace = require("al.workspace")
 local Lsp = require("al.lsp")
 
+--- Open the quickfix list with any ERROR-severity diagnostics, if there are
+--- any. al/createPackage's response has no error text of its own on
+--- failure; the actual compiler errors arrive via publishDiagnostics.
+local function show_error_diagnostics()
+    local errors = vim.diagnostic.get(nil, { severity = vim.diagnostic.severity.ERROR })
+    if #errors == 0 then
+        return
+    end
+    vim.diagnostic.setqflist({ title = "AL build errors", severity = vim.diagnostic.severity.ERROR })
+end
+
 local build_package = function()
     local co = coroutine.running()
     local fname = vim.api.nvim_buf_get_name(0)
@@ -44,6 +55,8 @@ local build_package = function()
             Util.info("Success: The package is created")
         else
             Util.error("Failed creating AL package\r\n" .. vim.inspect(result))
+            -- Give diagnostics for the failed files a moment to arrive.
+            vim.defer_fn(show_error_diagnostics, 300)
         end
         coroutine.resume(co)
     end)

--- a/lua/al/utils.lua
+++ b/lua/al/utils.lua
@@ -49,11 +49,78 @@ end
 
 M.get_clients = vim.lsp.get_clients
 
+--- Strip trailing commas from JSONC (before a closing ] or }), string-aware
+--- so a string value containing ",}" or ",]" isn't mistaken for one.
+---@param text string
+---@return string
+local function strip_trailing_commas(text)
+    local out = {}
+    local len = #text
+    local i = 1
+    local in_string = false
+    -- Buffered comma + following whitespace, held back until the next
+    -- non-whitespace character reveals whether it's a real separator (flush)
+    -- or a trailing comma before ]/} (drop).
+    local pending_comma_ws = nil
+
+    local function flush_pending()
+        if pending_comma_ws then
+            out[#out + 1] = ","
+            out[#out + 1] = pending_comma_ws
+            pending_comma_ws = nil
+        end
+    end
+
+    while i <= len do
+        local c = text:sub(i, i)
+
+        if in_string then
+            flush_pending()
+            out[#out + 1] = c
+            if c == "\\" and i < len then
+                out[#out + 1] = text:sub(i + 1, i + 1)
+                i = i + 2
+            else
+                if c == '"' then
+                    in_string = false
+                end
+                i = i + 1
+            end
+        elseif c == '"' then
+            flush_pending()
+            in_string = true
+            out[#out + 1] = c
+            i = i + 1
+        elseif c == "," and not pending_comma_ws then
+            pending_comma_ws = ""
+            i = i + 1
+        elseif pending_comma_ws and c:match("%s") then
+            pending_comma_ws = pending_comma_ws .. c
+            i = i + 1
+        elseif pending_comma_ws and (c == "]" or c == "}") then
+            pending_comma_ws = nil
+            out[#out + 1] = c
+            i = i + 1
+        else
+            flush_pending()
+            out[#out + 1] = c
+            i = i + 1
+        end
+    end
+    flush_pending()
+
+    return table.concat(out)
+end
+
+--- Read and parse a JSON(C) file. Tolerates comments and trailing commas,
+--- common in hand-edited VS Code .vscode/*.json files like launch.json.
+---@param path string
+---@return table
 function M.read_json_file(path)
     local f = assert(io.open(path))
     local content = f:read("*a")
     f:close()
-    local table_content = vim.json.decode(content)
+    local table_content = vim.json.decode(strip_trailing_commas(content), { skip_comments = true })
     return table_content
 end
 

--- a/tests/al/editor_commands/build_spec.lua
+++ b/tests/al/editor_commands/build_spec.lua
@@ -1,0 +1,109 @@
+local helpers = require("tests.helpers")
+
+describe("al.editor_commands.build", function()
+    local build
+
+    before_each(function()
+        package.loaded["al.editor_commands.build"] = nil
+        package.loaded["al.multiproject"] = {
+            project_for_buf = function() return "/test/project" end,
+        }
+        build = require("al.editor_commands.build")
+    end)
+
+    after_each(function()
+        package.loaded["al.multiproject"] = nil
+    end)
+
+    it("sends al/createPackage with the resolved project dir", function()
+        local client = helpers.make_mock_client({
+            responses = { ["al/createPackage"] = { result = { success = true } } },
+        })
+        local restore_lsp = helpers.stub_lsp_client(client)
+        local notify = helpers.capture_notify()
+
+        build()
+        helpers.flush()
+
+        assert.are.equal(1, #client.requests)
+        assert.are.equal("al/createPackage", client.requests[1].method)
+        assert.are.equal("/test/project", client.requests[1].params.projectDir)
+        restore_lsp()
+        notify.restore()
+    end)
+
+    it("notifies success when result.success is true", function()
+        local client = helpers.make_mock_client({
+            responses = { ["al/createPackage"] = { result = { success = true } } },
+        })
+        local restore_lsp = helpers.stub_lsp_client(client)
+        local notify = helpers.capture_notify()
+
+        build()
+        helpers.flush()
+
+        local found = false
+        for _, m in ipairs(notify.messages) do
+            if m.msg:match("Success") then found = true end
+        end
+        assert.is_true(found)
+        restore_lsp()
+        notify.restore()
+    end)
+
+    it("surfaces the full result (not just err) when result.success is false", function()
+        local client = helpers.make_mock_client({
+            responses = {
+                ["al/createPackage"] = {
+                    result = { success = false, errors = { "CompileError: 'X' does not exist" } },
+                },
+            },
+        })
+        local restore_lsp = helpers.stub_lsp_client(client)
+        local notify = helpers.capture_notify()
+
+        build()
+        helpers.flush()
+
+        local found = false
+        for _, m in ipairs(notify.messages) do
+            if m.msg:match("CompileError") then found = true end
+        end
+        assert.is_true(found)
+        restore_lsp()
+        notify.restore()
+    end)
+
+    it("errors clearly when no LSP client is attached", function()
+        local restore_lsp = helpers.stub_lsp_client(nil)
+        local notify = helpers.capture_notify()
+
+        build()
+
+        local found = false
+        for _, m in ipairs(notify.messages) do
+            if m.msg:match("No AL language server") then found = true end
+        end
+        assert.is_true(found)
+        restore_lsp()
+        notify.restore()
+    end)
+
+    it("errors clearly when the project directory cannot be determined", function()
+        package.loaded["al.multiproject"].project_for_buf = function() return nil end
+        package.loaded["al.workspace"] = { find = function() return nil end }
+        package.loaded["al.editor_commands.build"] = nil
+        build = require("al.editor_commands.build")
+
+        local notify = helpers.capture_notify()
+        build()
+
+        local found = false
+        for _, m in ipairs(notify.messages) do
+            if m.msg:match("Could not determine AL project directory") then found = true end
+        end
+        assert.is_true(found)
+        notify.restore()
+        package.loaded["al.workspace"] = nil
+    end)
+end)

--- a/tests/al/editor_commands/build_spec.lua
+++ b/tests/al/editor_commands/build_spec.lua
@@ -106,4 +106,78 @@ describe("al.editor_commands.build", function()
         notify.restore()
         package.loaded["al.workspace"] = nil
     end)
+
+    describe("on build failure", function()
+        local diag_ns
+
+        before_each(function()
+            diag_ns = vim.api.nvim_create_namespace("al_build_spec_test")
+        end)
+
+        after_each(function()
+            vim.diagnostic.reset(diag_ns)
+            vim.fn.setqflist({}, "r", { title = "", items = {} })
+        end)
+
+        it("opens the quickfix list with ERROR-severity diagnostics", function()
+            local buf = vim.api.nvim_create_buf(false, true)
+            vim.diagnostic.set(diag_ns, buf, {
+                { lnum = 4, col = 2, message = "CompileError: 'X' does not exist", severity = vim.diagnostic.severity.ERROR },
+            })
+
+            local client = helpers.make_mock_client({
+                responses = { ["al/createPackage"] = { result = { success = false, outputPath = "" } } },
+            })
+            local restore_lsp = helpers.stub_lsp_client(client)
+            local notify = helpers.capture_notify()
+
+            build()
+            helpers.flush()
+            vim.wait(400)
+
+            local qf = vim.fn.getqflist({ title = 0 })
+            assert.equals("AL build errors", qf.title)
+            assert.equals(1, #vim.fn.getqflist())
+            restore_lsp()
+            notify.restore()
+        end)
+
+        it("does not touch the quickfix list when there are no ERROR diagnostics", function()
+            vim.fn.setqflist({}, "r", { title = "unrelated", items = {} })
+
+            local client = helpers.make_mock_client({
+                responses = { ["al/createPackage"] = { result = { success = false, outputPath = "" } } },
+            })
+            local restore_lsp = helpers.stub_lsp_client(client)
+            local notify = helpers.capture_notify()
+
+            build()
+            helpers.flush()
+            vim.wait(400)
+
+            local qf = vim.fn.getqflist({ title = 0 })
+            assert.equals("unrelated", qf.title)
+            restore_lsp()
+            notify.restore()
+        end)
+
+        it("does not touch the quickfix list on a successful build", function()
+            vim.fn.setqflist({}, "r", { title = "unrelated", items = {} })
+
+            local client = helpers.make_mock_client({
+                responses = { ["al/createPackage"] = { result = { success = true } } },
+            })
+            local restore_lsp = helpers.stub_lsp_client(client)
+            local notify = helpers.capture_notify()
+
+            build()
+            helpers.flush()
+            vim.wait(400)
+
+            local qf = vim.fn.getqflist({ title = 0 })
+            assert.equals("unrelated", qf.title)
+            restore_lsp()
+            notify.restore()
+        end)
+    end)
 end)

--- a/tests/al/utils_spec.lua
+++ b/tests/al/utils_spec.lua
@@ -1,0 +1,76 @@
+describe("al.utils.read_json_file", function()
+    local utils
+
+    before_each(function()
+        package.loaded["al.utils"] = nil
+        utils = require("al.utils")
+    end)
+
+    local function write_file(content)
+        local path = vim.fn.tempname() .. ".json"
+        local f = assert(io.open(path, "w"))
+        f:write(content)
+        f:close()
+        return path
+    end
+
+    it("parses strict JSON", function()
+        local path = write_file('{"a": 1, "b": [1, 2, 3]}')
+        local data = utils.read_json_file(path)
+        assert.equals(1, data.a)
+        assert.same({ 1, 2, 3 }, data.b)
+    end)
+
+    it("strips a trailing comma before a closing ]", function()
+        local path = write_file('{"a": [1, 2, 3,]}')
+        local data = utils.read_json_file(path)
+        assert.same({ 1, 2, 3 }, data.a)
+    end)
+
+    it("strips a trailing comma before a closing }", function()
+        local path = write_file('{"a": 1, "b": 2,}')
+        local data = utils.read_json_file(path)
+        assert.equals(1, data.a)
+        assert.equals(2, data.b)
+    end)
+
+    it("strips nested trailing commas, matching a real launch.json shape", function()
+        local path = write_file([[
+{
+    "configurations": [
+        {
+            "name": "Launch",
+            "type": "al",
+        },
+    ]
+}
+]])
+        local data = utils.read_json_file(path)
+        assert.equals(1, #data.configurations)
+        assert.equals("Launch", data.configurations[1].name)
+    end)
+
+    it("tolerates // and /* */ comments (skip_comments)", function()
+        local path = write_file([[
+// header comment
+{
+    "a": 1, /* inline */ "b": 2
+}
+]])
+        local data = utils.read_json_file(path)
+        assert.equals(1, data.a)
+        assert.equals(2, data.b)
+    end)
+
+    it("does not strip a comma that is part of a string value", function()
+        local path = write_file('{"a": "literally ,}"}')
+        local data = utils.read_json_file(path)
+        assert.equals("literally ,}", data.a)
+    end)
+
+    it("errors for a nonexistent file", function()
+        assert.has_error(function()
+            utils.read_json_file("/nonexistent/path/launch.json")
+        end)
+    end)
+end)


### PR DESCRIPTION
## Summary

Three related fixes to build-failure visibility, all uncovered while debugging a real failing build against a production BC repo:

1. **`read_json_file` tolerates JSONC** — `.vscode/launch.json` is commonly hand-edited in VS Code, which accepts trailing commas and comments freely. `vim.json.decode` doesn't, so a real-world file with a single trailing comma failed to parse entirely, surfacing as al.nvim's generic "Could not read launch.json" even though the file works fine in VS Code. Added a string-aware trailing-comma stripper (doesn't get confused by commas inside string values) plus `skip_comments = true` for `//`/`/* */` support.

2. **Surface actual build failure details** — `al/createPackage`'s response has no top-level error object on a failed build (`err` is always `nil`; it's `result.success = false` that signals failure). The error branch was printing `vim.inspect(err)` — always `"nil"` — discarding whatever the server actually returned. Now prints `vim.inspect(result)` instead, so real diagnostic fields are visible.

3. **Auto-open quickfix with compiler errors on build failure** — the actual compiler errors aren't in `al/createPackage`'s response at all; they arrive separately via standard `textDocument/publishDiagnostics` (same mechanism VS Code's Problems panel reads from). After a failed build, if there are any ERROR-severity diagnostics known to Neovim, populate and open the quickfix list with them automatically instead of requiring the user to go check diagnostics manually.

Each commit is independent and comes with its own test coverage (7 + 5 + 3 tests). Verified end-to-end against a real failing `launch.json` and a real failed build.